### PR TITLE
fixes for strict compilers

### DIFF
--- a/src/ofxBlur.cpp
+++ b/src/ofxBlur.cpp
@@ -50,6 +50,7 @@ string generateBlurSource(int radius, float shape) {
 	
 	stringstream src;
     src << "#version 120\n";
+	src << "#extension GL_ARB_texture_rectangle : enable\n";
 	src << "uniform sampler2DRect source;\n";
 	src << "uniform vec2 direction;\n";
 	src << "void main(void) {\n";
@@ -73,6 +74,7 @@ string generateCombineSource(int passes, float downsample) {
 	}
 	stringstream src;
     src << "#version 120\n";
+	src << "#extension GL_ARB_texture_rectangle : enable\n";
 	src << "uniform sampler2DRect " << ofJoinString(combineNames, ",") << ";\n";
 	src << "uniform float brightness;\n";
 	if(downsample == 1) {


### PR DESCRIPTION
the shader sometimes fails to compile without this flag on some systems.

tested on a Windows 8 laptop with a GTX980M
